### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "directories": {
     "test": "tests"
   },
-  "dependencies": {
+  "devDependencies": {
     "nodeunit": "~0.7.4"
   },
   "keywords": [


### PR DESCRIPTION
nodeunit should be a dev dependency since it's only used in tests. This will allow for faster installations when installing with `--production` argument.

Keep in mind that nodeunit has a big dependency tree. It's dependent on `tap` which is dependent on 16 other dependencies and it keeps going several levels.
